### PR TITLE
Add WASM-ready document translation pipeline scaffolding

### DIFF
--- a/packages/utils/README.md
+++ b/packages/utils/README.md
@@ -26,6 +26,11 @@ Export an Excalidraw diagram to a [Blob](https://developer.mozilla.org/en-US/doc
 
 Export an Excalidraw diagram to a [SVGElement](https://developer.mozilla.org/en-US/docs/Web/API/SVGElement).
 
+
+### `createDocumentTranslationPipeline`
+
+Builds a JS translation pipeline for `.docx`, `.odt`, `.doc`, and `.pdf` files where a WebAssembly runtime handles document I/O and a translation client (for example, Gamma translation APIs) translates extracted text segments before rebuilding the file.
+
 ## Usage
 
 Excalidraw utils is published as a UMD (Universal Module Definition). If you are using a module bundler (for instance, Webpack), you can import it as an ES6 module:

--- a/packages/utils/src/documentTranslationPipeline.ts
+++ b/packages/utils/src/documentTranslationPipeline.ts
@@ -1,0 +1,200 @@
+export type SupportedDocumentFormat = "docx" | "odt" | "doc" | "pdf";
+
+export type TranslationSegment = {
+  id: string;
+  text: string;
+  path: string;
+  metadata?: Record<string, unknown>;
+};
+
+export type TranslationResult = {
+  translatedText: string;
+  detectedSourceLanguage?: string;
+};
+
+export type TranslationCallContext = {
+  sourceLanguage?: string;
+  targetLanguage: string;
+  signal?: AbortSignal;
+};
+
+export type StructuredDocument = {
+  format: SupportedDocumentFormat;
+  binary: Uint8Array;
+  segments: TranslationSegment[];
+  manifest?: Record<string, unknown>;
+};
+
+export type ParseDocumentInput = {
+  bytes: Uint8Array;
+  signal?: AbortSignal;
+};
+
+export type RenderDocumentInput = {
+  sourceBytes: Uint8Array;
+  translatedSegments: Map<string, string>;
+  structuredDocument: StructuredDocument;
+  signal?: AbortSignal;
+};
+
+export type DocumentAdapter = {
+  parse(input: ParseDocumentInput): Promise<StructuredDocument>;
+  render(input: RenderDocumentInput): Promise<Uint8Array>;
+};
+
+export type WasmDocumentRuntime = {
+  readDocument(
+    format: SupportedDocumentFormat,
+    bytes: Uint8Array,
+    signal?: AbortSignal,
+  ): Promise<Uint8Array>;
+  writeDocument(
+    format: SupportedDocumentFormat,
+    bytes: Uint8Array,
+    signal?: AbortSignal,
+  ): Promise<Uint8Array>;
+};
+
+export type TranslationClient = {
+  translate(
+    segment: TranslationSegment,
+    context: TranslationCallContext,
+  ): Promise<TranslationResult>;
+};
+
+export type TranslationPipelineOptions = {
+  runtime: WasmDocumentRuntime;
+  adapters: Record<SupportedDocumentFormat, DocumentAdapter>;
+  translationClient: TranslationClient;
+  maxParallelSegments?: number;
+};
+
+export type TranslateDocumentInput = {
+  fileName: string;
+  bytes: Uint8Array;
+  targetLanguage: string;
+  sourceLanguage?: string;
+  signal?: AbortSignal;
+};
+
+export type TranslateDocumentOutput = {
+  format: SupportedDocumentFormat;
+  translatedBytes: Uint8Array;
+  translatedSegments: number;
+};
+
+const DEFAULT_MAX_PARALLEL_SEGMENTS = 5;
+
+const FORMAT_BY_EXTENSION: Record<string, SupportedDocumentFormat> = {
+  ".docx": "docx",
+  ".odt": "odt",
+  ".doc": "doc",
+  ".pdf": "pdf",
+};
+
+const normalizeFileName = (fileName: string) => fileName.trim().toLowerCase();
+
+export const getDocumentFormat = (
+  fileName: string,
+): SupportedDocumentFormat | null => {
+  const normalizedName = normalizeFileName(fileName);
+  const ext = Object.keys(FORMAT_BY_EXTENSION).find((candidate) =>
+    normalizedName.endsWith(candidate),
+  );
+  return ext ? FORMAT_BY_EXTENSION[ext] : null;
+};
+
+const assertAbortNotRequested = (signal?: AbortSignal) => {
+  if (signal?.aborted) {
+    throw new DOMException("Translation request was aborted", "AbortError");
+  }
+};
+
+const createSegmentTranslationQueue = async (
+  segments: TranslationSegment[],
+  runTask: (segment: TranslationSegment) => Promise<void>,
+  concurrency: number,
+) => {
+  const workers = Array.from({ length: Math.min(concurrency, segments.length) });
+  let index = 0;
+
+  await Promise.all(
+    workers.map(async () => {
+      while (index < segments.length) {
+        const nextIndex = index;
+        index += 1;
+        await runTask(segments[nextIndex]);
+      }
+    }),
+  );
+};
+
+export const createDocumentTranslationPipeline = (
+  options: TranslationPipelineOptions,
+) => {
+  const maxParallelSegments =
+    options.maxParallelSegments ?? DEFAULT_MAX_PARALLEL_SEGMENTS;
+
+  return {
+    async translateDocument(
+      input: TranslateDocumentInput,
+    ): Promise<TranslateDocumentOutput> {
+      assertAbortNotRequested(input.signal);
+
+      const format = getDocumentFormat(input.fileName);
+
+      if (!format) {
+        throw new Error(
+          `Unsupported file format for ${input.fileName}. Supported formats are: docx, odt, doc, pdf`,
+        );
+      }
+
+      const adapter = options.adapters[format];
+      const wasmReadable = await options.runtime.readDocument(
+        format,
+        input.bytes,
+        input.signal,
+      );
+
+      const structuredDocument = await adapter.parse({
+        bytes: wasmReadable,
+        signal: input.signal,
+      });
+
+      const translatedSegments = new Map<string, string>();
+
+      await createSegmentTranslationQueue(
+        structuredDocument.segments,
+        async (segment) => {
+          assertAbortNotRequested(input.signal);
+          const result = await options.translationClient.translate(segment, {
+            sourceLanguage: input.sourceLanguage,
+            targetLanguage: input.targetLanguage,
+            signal: input.signal,
+          });
+          translatedSegments.set(segment.id, result.translatedText);
+        },
+        maxParallelSegments,
+      );
+
+      const renderedDocument = await adapter.render({
+        sourceBytes: wasmReadable,
+        translatedSegments,
+        structuredDocument,
+        signal: input.signal,
+      });
+
+      const wasmWritable = await options.runtime.writeDocument(
+        format,
+        renderedDocument,
+        input.signal,
+      );
+
+      return {
+        format,
+        translatedBytes: wasmWritable,
+        translatedSegments: translatedSegments.size,
+      };
+    },
+  };
+};

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -2,3 +2,5 @@ export * from "./export";
 export * from "./withinBounds";
 export * from "./bbox";
 export { getCommonBounds } from "@excalidraw/element";
+
+export * from "./documentTranslationPipeline";

--- a/packages/utils/tests/documentTranslationPipeline.test.ts
+++ b/packages/utils/tests/documentTranslationPipeline.test.ts
@@ -1,0 +1,101 @@
+import {
+  createDocumentTranslationPipeline,
+  getDocumentFormat,
+  type DocumentAdapter,
+  type SupportedDocumentFormat,
+  type TranslationClient,
+  type WasmDocumentRuntime,
+} from "../src";
+
+describe("getDocumentFormat", () => {
+  it("resolves supported formats", () => {
+    expect(getDocumentFormat("proposal.DOCX")).toBe("docx");
+    expect(getDocumentFormat("localization.odt")).toBe("odt");
+    expect(getDocumentFormat("legacy.doc")).toBe("doc");
+    expect(getDocumentFormat("report.pdf")).toBe("pdf");
+  });
+
+  it("returns null for unsupported formats", () => {
+    expect(getDocumentFormat("slides.pptx")).toBeNull();
+  });
+});
+
+describe("createDocumentTranslationPipeline", () => {
+  const encodedText = new TextEncoder().encode("sample");
+
+  const createAdapter = (format: SupportedDocumentFormat): DocumentAdapter => ({
+    parse: async ({ bytes }) => ({
+      format,
+      binary: bytes,
+      segments: [
+        { id: "title", text: "Hello", path: "body/title" },
+        { id: "body", text: "How are you?", path: "body/paragraph/0" },
+      ],
+    }),
+    render: async ({ translatedSegments }) =>
+      new TextEncoder().encode(
+        JSON.stringify({
+          title: translatedSegments.get("title"),
+          body: translatedSegments.get("body"),
+        }),
+      ),
+  });
+
+  const runtime: WasmDocumentRuntime = {
+    readDocument: async (_format, bytes) => bytes,
+    writeDocument: async (_format, bytes) => bytes,
+  };
+
+  const translationClient: TranslationClient = {
+    translate: async (segment, context) => ({
+      translatedText: `${segment.text} (${context.targetLanguage})`,
+    }),
+  };
+
+  const adapters = {
+    docx: createAdapter("docx"),
+    odt: createAdapter("odt"),
+    doc: createAdapter("doc"),
+    pdf: createAdapter("pdf"),
+  };
+
+  it("translates a supported document and preserves segment mapping", async () => {
+    const pipeline = createDocumentTranslationPipeline({
+      runtime,
+      adapters,
+      translationClient,
+      maxParallelSegments: 2,
+    });
+
+    const translated = await pipeline.translateDocument({
+      fileName: "contract.docx",
+      bytes: encodedText,
+      targetLanguage: "es",
+    });
+
+    expect(translated.format).toBe("docx");
+    expect(translated.translatedSegments).toBe(2);
+
+    const output = JSON.parse(new TextDecoder().decode(translated.translatedBytes));
+    expect(output).toEqual({
+      title: "Hello (es)",
+      body: "How are you? (es)",
+    });
+  });
+
+  it("throws on unsupported formats", async () => {
+    const pipeline = createDocumentTranslationPipeline({
+      runtime,
+      adapters,
+      translationClient,
+    });
+
+    await expect(
+      pipeline.translateDocument({
+        fileName: "deck.pptx",
+        bytes: encodedText,
+        targetLanguage: "fr",
+      }),
+    ).rejects.toThrow("Unsupported file format");
+  });
+});


### PR DESCRIPTION
### Motivation

- Provide a reusable JS pipeline to translate office and PDF documents while allowing a WebAssembly runtime to handle format-preserving I/O and adapters to preserve fidelity during parse/render.  

### Description

- Add a new pipeline API `createDocumentTranslationPipeline` with types and runtime/adapter/client interfaces in `packages/utils/src/documentTranslationPipeline.ts`.  
- Add format detection via `getDocumentFormat` for `.docx`, `.odt`, `.doc`, and `.pdf` and a segment-based translation queue with configurable concurrency.  
- Export the new API from `packages/utils/src/index.ts` and document the API in `packages/utils/README.md`.  
- Add unit tests in `packages/utils/tests/documentTranslationPipeline.test.ts` that cover format detection, a successful translation flow (adapter + wasm runtime + mock translation client), and unsupported-format rejection.  

### Testing

- Added unit tests in `packages/utils/tests/documentTranslationPipeline.test.ts` but running `yarn vitest` failed in this environment because the `vitest` binary is not available (`error: Command "vitest" not found`).  
- Attempting to run the local binary `./node_modules/.bin/vitest` also failed because no local binary exists in this environment.  
- Running `yarn prettier --check` on the new files failed due to a missing project prettier config dependency (`@excalidraw/prettier-config`) in this environment.  
- The tests are present and expected to pass in a normal developer environment after running `yarn install` to restore dev dependencies and then executing `yarn vitest`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2986df5f48330a1b6dc0c2848a76b)